### PR TITLE
Update ElevenLabs JS Library npm URL

### DIFF
--- a/fern/docs/pages/developer-guides/libraries.mdx
+++ b/fern/docs/pages/developer-guides/libraries.mdx
@@ -7,10 +7,10 @@ subtitle: Explore language-specific libraries for using the ElevenLabs API.
 
 ElevenLabs provides officially supported libraries that are updated with the latest features available in the [REST API](/docs/api-reference/introduction).
 
-| Language          | GitHub                                                           | Package Manager                                 |
-| ----------------- | ---------------------------------------------------------------- | ----------------------------------------------- |
-| Python            | [GitHub README](https://github.com/elevenlabs/elevenlabs-python) | [PyPI](https://pypi.org/project/elevenlabs/)    |
-| Javascript (Node) | [GitHub README](https://github.com/elevenlabs/elevenlabs-js)     | [npm](https://www.npmjs.com/package/elevenlabs) |
+| Language          | GitHub                                                           | Package Manager                                                |
+| ----------------- | ---------------------------------------------------------------- | -------------------------------------------------------------- |
+| Python            | [GitHub README](https://github.com/elevenlabs/elevenlabs-python) | [PyPI](https://pypi.org/project/elevenlabs/)                   |
+| Javascript (Node) | [GitHub README](https://github.com/elevenlabs/elevenlabs-js)     | [npm](https://www.npmjs.com/package/@elevenlabs/elevenlabs-js) |
 
 Test and explore all ElevenLabs API endpoints using our official [Postman collection](https://www.postman.com/elevenlabs/elevenlabs/collection/7i9rytu/elevenlabs-api-documentation?action=share&creator=39903018).
 


### PR DESCRIPTION
`@elevenlabs/elevenlabs-js` npm link was pointing to deprecated [`elevenlabs` package page](https://www.npmjs.com/package/elevenlabs)